### PR TITLE
Make extensions available publicly

### DIFF
--- a/Sources/HsExtensions/Data.swift
+++ b/Sources/HsExtensions/Data.swift
@@ -10,7 +10,7 @@ public extension Data {
 
 }
 
-extension Data: IHsExtension {}
+public extension Data: IHsExtension {}
 
 public extension HsExtension where Base == Data {
 


### PR DESCRIPTION
Extension itself should be `public` to be available from the outside